### PR TITLE
Quick fix: removes redundant scrollbar

### DIFF
--- a/wongnung/templates/wongnung/profile_page.html
+++ b/wongnung/templates/wongnung/profile_page.html
@@ -40,7 +40,7 @@
                </form>
           </div>
      </div>
-     <div class="bg-feed-grey mx-6 w-full h-screen overflow-y-scroll scrollbar">
+     <div class="bg-feed-grey mx-6 w-full h-screen">
           <div class="flex flow-col" id="ShowComponent">
           </div>
      </div>


### PR DESCRIPTION
In profile bookmark page, there are too many scrollbars appearing on screen (expected 2)

This PR fixes that.

![image](https://user-images.githubusercontent.com/39559733/204487804-e314ff22-2918-49e4-8eb7-c28ce71a8836.png)
