### PR TITLE
Add reCAPTCHA Verification to Review Posting Process

### DIFF
--- a/pdtx/settings.py
+++ b/pdtx/settings.py
@@ -68,6 +68,8 @@ INSTALLED_APPS = [
     "theme",
     "django_htmx",
     'pgcrypto',
+
+    'django_recaptcha',
 ]
 
 if DEBUG:
@@ -329,3 +331,6 @@ LOGGING = {
 }
 
 AUTH_USER_MODEL = 'wongnung.CustomUser'
+
+RECAPTCHA_PUBLIC_KEY = config("RECAPTCHA_PUBLIC_KEY")
+RECAPTCHA_PRIVATE_KEY = config("RECAPTCHA_PRIVATE_KEY")

--- a/wongnung/templates/wongnung/post_review_page.html
+++ b/wongnung/templates/wongnung/post_review_page.html
@@ -13,7 +13,7 @@
                           >{% if review %}{{ review.content }}{% endif %}</textarea>
             </div>
             <div class="flex items-center justify-between px-10 mt-5">
-                <div class="g-recaptcha" data-sitekey="6LfYadIpAAAAABtbCQqpEPAgmWiLPYnMca6of3d7"></div>
+                <div class="g-recaptcha" data-sitekey={{captcha_key}}></div>
                 <input type="submit" name="submit" class="bg-component-red h-10 w-16 mt-5 rounded-lg text-white flex items-center justify-center self-end float-right mr-10" value="Post" />
             </div>
         </form>

--- a/wongnung/views/review_posting.py
+++ b/wongnung/views/review_posting.py
@@ -1,4 +1,5 @@
 import logging
+import requests
 from re import findall
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, render
@@ -9,8 +10,10 @@ from ..insights import UserWritesReview
 from ..models.film import Film
 from ..models.review import Review
 from . import user_insights
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
+
 
 @login_required
 def post_review_page(request, filmid):
@@ -22,9 +25,22 @@ def post_review_page(request, filmid):
         "profile": request.user.userprofile,
     }
     review = Review.objects.filter(film=film, author=request.user).first()
+    context["captcha_key"] = settings.RECAPTCHA_PUBLIC_KEY
     if review:
         context["review"] = review
     return render(request, "wongnung/post_review_page.html", context)
+
+
+def verify_recaptcha(response):
+    """Verifies the recaptcha response."""
+    data = {
+        "secret": settings.RECAPTCHA_PRIVATE_KEY,
+        "response": response,
+    }
+    result = requests.post(
+        "https://www.google.com/recaptcha/api/siteverify", data=data
+    )
+    return result.json().get("success", False)
 
 
 def post_review(request, filmid):
@@ -32,7 +48,13 @@ def post_review(request, filmid):
     author = request.user
     film = Film.get_film(filmid)
     content = request.POST["content"].strip()
-    if not content:
+    recaptcha_response = request.POST["g-recaptcha-response"]
+
+    if (
+        not recaptcha_response
+        or not content
+        or not verify_recaptcha(recaptcha_response)
+    ):
         return redirect("wongnung:new-review", filmid=filmid)
 
     # Quick-and-dirty sanitization
@@ -43,11 +65,15 @@ def post_review(request, filmid):
     if review:
         review.content = content
         review.save()
-        logger.info(f"Updated review with id {review.id} for film {filmid} by user {request.user.username}.")
+        logger.info(
+            f"Updated review with id {review.id} for film {filmid} by user {request.user.username}."
+        )
     else:
         review = Review.objects.create(
             film=film, content=content, author=author
         )
-        logger.info(f"Created review with id {review.id} for film {filmid} by user {request.user.username}.")
+        logger.info(
+            f"Created review with id {review.id} for film {filmid} by user {request.user.username}."
+        )
     user_insights.push(author, UserWritesReview(film, review))
     return redirect("wongnung:film-details", filmid=filmid)


### PR DESCRIPTION
This pull request introduces backend verification for reCAPTCHA in the review posting workflow to enhance security and prevent spam. Changes have been made to ensure that a review can only be posted after a successful reCAPTCHA validation.

Key Changes:

- Settings Updated: Added django_recaptcha to installed apps and configured public and private reCAPTCHA keys.
- Template Modifications: Updated the reCAPTCHA div in post_review_page.html to use a dynamic site key from the settings.
- Backend Logic: Added a new function verify_recaptcha to validate the reCAPTCHA response with Google's verification service.
- View Adjustments: Updated post_review to include a check for the reCAPTCHA response before processing the review content.